### PR TITLE
Position added to Academic Staff

### DIFF
--- a/lambda-learn.sql
+++ b/lambda-learn.sql
@@ -19,7 +19,6 @@ CREATE TABLE Student (
     index_no INT NOT NULL,
     date_joined DATETIME NOT NULL,
     degree_program_code VARCHAR(5) NOT NULL,
-    position VARCHAR(20) NOT NULL,
     CONSTRAINT PK_Student PRIMARY KEY (reg_no)
 );
 
@@ -37,6 +36,7 @@ CREATE TABLE AcademicStaff (
     active_status BOOLEAN,
     profile_picture VARCHAR(100),
     degree_program_code VARCHAR(5),
+    position VARCHAR(20) NOT NULL,
     CONSTRAINT PK_AcademicStaff PRIMARY KEY (reg_no)
 );
 


### PR DESCRIPTION
Position attribute had been mistakenly added to the student table instead of academic staff table in table creation queries. 
It has been resolved